### PR TITLE
Update package.json, include main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "homepage": "http://mozilla.github.io/pdf.js/",
   "bugs": "https://github.com/mozilla/pdf.js/issues",
   "license": "Apache-2.0",
+  "main": "build/pdf.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/mozilla/pdfjs-dist"


### PR DESCRIPTION
When using webpack, having a "main" field in package.json allows for the file to be pulled in more easily.