### PR TITLE
chore: remove WebPack as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
     "node-ensure": "^0.0.0",
     "worker-loader": "^2.0.0"
   },
-  "peerDependencies": {
-    "webpack": "^3.0.0 || ^4.0.0-alpha.0 || ^4.0.0"
-  },
   "browser": {
     "fs": false,
     "http": false,


### PR DESCRIPTION
When you set Webpack as a peer dependency, consumers receive a warning that Webpack should be added as a peerDependency or dependency to consume this library. That warning is inaccurate.