### PR TITLE
Fix PDFObjects getter signature

### DIFF
--- a/types/src/display/api.d.ts
+++ b/types/src/display/api.d.ts
@@ -1417,7 +1417,7 @@ declare class PDFObjects {
      * object once the object is resolved. That means, if you call this method
      * and the object is already resolved, the callback gets called right away.
      */
-    get(objId: any, callback?: null): any;
+    get(objId: any, callback?: any): any;
     has(objId: any): any;
     /**
      * Resolves the object `objId` with optional `data`.


### PR DESCRIPTION
In PDF.js/display/api.js the getter signature for class PDFObjects is:
get(objId, callback = null)
which is wrongly described in project's types/src/display/api.d.ts with:
get(objId: any, callback?: null): any;

The callback is already described as an optional parameter. A callback function must not be of type null.
