### PR TITLE
DocumentInitParameters can use Blob.arrayBuffer()

### DIFF
--- a/types/src/display/api.d.ts
+++ b/types/src/display/api.d.ts
@@ -16,7 +16,7 @@ export type DocumentInitParameters = {
      * typed arrays (Uint8Array) to improve the memory usage. If PDF data is
      * BASE64-encoded, use `atob()` to convert it to a binary string first.
      */
-    data?: string | number[] | TypedArray | undefined;
+    data?: string | number[] | TypedArray | ArrayBuffer | undefined;
     /**
      * - Basic authentication headers.
      */


### PR DESCRIPTION
## problem
I want to use ArrayBuffer, but I don't have enough types.

## usecase
```typescript
async loadPDF (data: File) {
      const arrayData = await data.arrayBuffer()
      const pdf = await pdfJS.getDocument({
        data: arrayData
      }).promise
    }
```