### PR TITLE
Replace eval with function because of security risks

### DIFF
--- a/legacy/build/pdf.js
+++ b/legacy/build/pdf.js
@@ -5467,7 +5467,7 @@ class PDFWorker {
         return mainWorkerMessageHandler;
       }
       if (_is_node.isNodeJS && typeof require === "function") {
-        const worker = eval("require")(this.workerSrc);
+        const worker = require(this.workerSrc);
         return worker.WorkerMessageHandler;
       }
       await (0, _display_utils.loadScript)(this.workerSrc);


### PR DESCRIPTION
I got the following warn in nuxt project
```
Use of eval in "../../../root/.cache/c12/bitbucket_alwasaet_alwasaet-ui/node_modules/vue3-pdfjs/node_modules/pdfjs-dist/legacy/build/pdf.js" is strongly discouraged as it poses security risks and may cause issues with minification.
```